### PR TITLE
feat: user online status

### DIFF
--- a/pongWorld/player/apps.py
+++ b/pongWorld/player/apps.py
@@ -1,6 +1,24 @@
+import os 
+import sys
+
 from django.apps import AppConfig
 
 
 class PlayerConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'player'
+
+    def ready(self):
+
+        def reset_online_count():
+            Player.objects.update(online_count = 0)
+
+        if 'runserver' not in sys.argv:
+            return True
+
+        from django.db.models.signals import post_migrate
+        from player.models import Player
+        
+        if not os.environ.get('RESET_ONLINE_COUNT'):
+            os.environ['RESET_ONLINE_COUNT'] = 'True'
+            reset_online_count()

--- a/pongWorld/player/models/player.py
+++ b/pongWorld/player/models/player.py
@@ -33,12 +33,13 @@ class PlayerManager(BaseUserManager):
 class Player(AbstractBaseUser, TimestampBaseModel, PermissionsMixin):
     nickname    = models.CharField(max_length=10, unique=True)
     email       = models.EmailField(max_length=30, unique=True)
-    # profile_img = models.URLField(blank=True, null=True)
     profile_img = models.ImageField(upload_to='profile_imgs', default=None, blank=True, null=True)
     intro       = models.CharField(max_length=200, default='', blank=True)
     matches     = models.PositiveIntegerField(default=0)
     wins        = models.PositiveIntegerField(default=0)
     total_score = models.PositiveIntegerField(default=0)
+    online_count = models.PositiveIntegerField(default=0)
+    last_login_time = models.DateTimeField()
 
     objects = PlayerManager()
 

--- a/pongWorld/player/serializers/player.py
+++ b/pongWorld/player/serializers/player.py
@@ -6,10 +6,12 @@ from drf_spectacular.utils import OpenApiTypes
 
 
 class PlayerSerializer(serializers.ModelSerializer):
+    is_online = serializers.SerializerMethodField()
+
     class Meta:
         model = Player
         profile_img = serializers.ImageField(use_url=True)
-        fields = ["id", "nickname", "email", "profile_img", "intro", "matches", "wins", "total_score"]
+        fields = ["id", "nickname", "email", "profile_img", "intro", "matches", "wins", "total_score", "is_online"]
         extra_kwargs = {
             "id": {"read_only": True},
             "email": {"read_only": True},
@@ -24,6 +26,9 @@ class PlayerSerializer(serializers.ModelSerializer):
 
             if Player.objects.filter(nickname=value).exclude(id=instance_id).exists():
                 raise serializers.ValidationError("This nickname already exists.")
+
+    def get_is_online(self, obj):
+        return obj.online_count > 0
 
     @extend_schema_field(OpenApiTypes.INT)
     def get_id(self, obj):

--- a/pongWorld/player/urls.py
+++ b/pongWorld/player/urls.py
@@ -3,9 +3,10 @@ from . import views
 
 # Create a router and register our viewsets with it.
 # router = DefaultRouter()
-app_name = "player"
+app_name = 'player'
 
 # The API URLs are now determined automatically by the router.
 urlpatterns = [
-    path("", views.PlayerRetrieveUpdateDestroyView.as_view()),
+    path('', views.PlayerRetrieveUpdateDestroyView.as_view()),
+    path('online/', views.OnlinePlayerListView.as_view())
 ]

--- a/pongWorld/player/views/__init__.py
+++ b/pongWorld/player/views/__init__.py
@@ -1,1 +1,1 @@
-from .player import PlayerRetrieveUpdateDestroyView
+from .player import PlayerRetrieveUpdateDestroyView, OnlinePlayerListView

--- a/pongWorld/player/views/player.py
+++ b/pongWorld/player/views/player.py
@@ -1,4 +1,5 @@
 from rest_framework import generics
+from rest_framework.pagination import CursorPagination
 from django.http import Http404
 
 from ..models import Player
@@ -13,3 +14,15 @@ class PlayerRetrieveUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
             return Player.objects.get(id=user_id)
         except Player.DoesNotExist:
             raise Http404
+
+class CustomPlayerPagination(CursorPagination):
+    page_size = 30
+    ordering = '-last_login_time'
+class OnlinePlayerListView(generics.ListAPIView):
+    serializer_class = PlayerSerializer
+    pagination_class = CustomPlayerPagination
+
+    def get_queryset(self):
+        user_id = self.request.user.id
+        return Player.objects.filter(online_count__gt=0).exclude(id=user_id)
+

--- a/pongWorld/websocket/consumers.py
+++ b/pongWorld/websocket/consumers.py
@@ -2,21 +2,19 @@ import json
 
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
+from django.db.models import F
 from django.utils import timezone
 
 from chat.socket.mixins import ChatMixin
 from game.socket.match_consumers import GameMixin
-
-online_users = set()
+from player.models import Player
 
 class ConnectConsumer(AsyncWebsocketConsumer, ChatMixin, GameMixin):
     async def connect(self):
-        global online_users
         self.user = self.scope['user']
 
         if self.user.is_authenticated:
             self.player_id = self.user.id
-            online_users.add(self.player_id)
 
             self.online_users_group = 'online_users'
             self.player_group = f'player_{self.player_id}'
@@ -25,45 +23,49 @@ class ConnectConsumer(AsyncWebsocketConsumer, ChatMixin, GameMixin):
 
             await self.accept()
 
-            await self.send_online_users()
-            await self.channel_layer.group_send(
-                self.online_users_group,
-                {
-                    'type': 'user.online',
-                    'user_id': self.player_id
-                }
-            )
+            await self.update_user_connection()
+            # await self.channel_layer.group_send(
+            #     self.online_users_group,
+            #     {
+            #         'type': 'user.online',
+            #         'user_id': self.player_id
+            #     }
+            # )
         else:
             await self.close()
 
-    async def user_online(self, event):
-        await self.send(text_data=json.dumps({
-            'type': 'user_online',
-            'user_id': event['user_id']
-        }))
-    async def user_offline(self, event):
-        await self.send(text_data=json.dumps({
-            'type': 'user_offline',
-            'user_id': event['user_id']
-        }))
+    @database_sync_to_async
+    def update_user_connection(self):
+        Player.objects.filter(id=self.user.id).update(online_count=F('online_count')+1)
+        Player.objects.filter(id=self.user.id).update(last_login_time=timezone.now())
 
-    async def send_online_users(self):
-        await self.send(text_data=json.dumps({
-            'online_users': list(online_users)
-        }))
+    @database_sync_to_async
+    def update_user_disconnection(self):
+        Player.objects.filter(id=self.user.id).update(online_count=F('online_count')-1)
+    
+    # async def user_online(self, event):
+    #     await self.send(text_data=json.dumps({
+    #         'type': 'user_online',
+    #         'user_id': event['user_id']
+    #     }))
+    # async def user_offline(self, event):
+    #     await self.send(text_data=json.dumps({
+    #         'type': 'user_offline',
+    #         'user_id': event['user_id']
+    #     }))
 
     async def disconnect(self, close_code):
         if self.user.is_authenticated:
+            await self.update_user_disconnection()
             await self.channel_layer.group_discard(self.online_users_group, self.channel_name)
             await self.channel_layer.group_discard(self.player_group, self.channel_name)
-            online_users.remove(self.player_id)
-            await self.channel_layer.group_send(
-                self.online_users_group,
-                {
-                    'type': 'user.offline',
-                    'user_id': self.player_id
-                }
-            )
+            # await self.channel_layer.group_send(
+            #     self.online_users_group,
+            #     {
+            #         'type': 'user.offline',
+            #         'user_id': self.player_id
+            #     }
+            # )
 
     async def receive(self, text_data=None, bytes_data=None):
         try:


### PR DESCRIPTION
### 구현 사항 
- 유저 모델 수정 (online_count, last_login_time 추가)
   - makemigrations, migrate 필요 
- 온라인 유저 list get api 추가 (GET /player/online/)

### 테스트 
- 온라인 유저 리스트 가져오기 
<img width="705" alt="image" src="https://github.com/Tscen-Rangers/PongWorld-Server/assets/86519350/07d43a94-b512-44e9-920b-887af788443b">
