### PR TITLE
feat: 유저 프로필 조회 api 구현

### DIFF
--- a/pongWorld/player/urls.py
+++ b/pongWorld/player/urls.py
@@ -4,8 +4,9 @@ from . import views
 app_name = "player"
 
 urlpatterns = [
-    path('online/', views.OnlinePlayerListView.as_view())
+    path('online/', views.OnlinePlayerListView.as_view()),
     path('', views.PlayerRetrieveUpdateDestroyView.as_view(), name="player_detail"),
+    path('profile/<int:user_id>/', views.PlayerProfileView.as_view({'get': 'get_player_profile'}), name="player_profile"),
     path("friends/request/<int:followed_id>/", views.FriendReqResView.as_view({'post': 'request_friend'}), name="request_friend"),
     path("friends/response/<int:friend_id>/", views.FriendReqResView.as_view({'patch': 'response_friend', 'delete': 'response_friend'}), name="response_friend"),
     path("friends/request/send/", views.FriendReqResView.as_view({'get': 'send_req_list'}), name="send_req_list"),

--- a/pongWorld/player/views/__init__.py
+++ b/pongWorld/player/views/__init__.py
@@ -1,3 +1,3 @@
 
-from .player import PlayerRetrieveUpdateDestroyView , OnlinePlayerListView
+from .player import PlayerRetrieveUpdateDestroyView , OnlinePlayerListView, PlayerProfileView
 from .friend import FriendReqResView

--- a/pongWorld/player/views/player.py
+++ b/pongWorld/player/views/player.py
@@ -1,6 +1,7 @@
-from rest_framework import generics
+from rest_framework import generics, viewsets, status
 from rest_framework.pagination import CursorPagination
 from django.http import Http404
+from rest_framework.response import Response
 
 from ..models import Player
 from ..serializers import PlayerSerializer
@@ -25,4 +26,34 @@ class OnlinePlayerListView(generics.ListAPIView):
     def get_queryset(self):
         user_id = self.request.user.id
         return Player.objects.filter(online_count__gt=0).exclude(id=user_id)
+
+class PlayerProfileView(viewsets.ModelViewSet):
+    serializer_class = PlayerSerializer
+
+    def get_player_profile(self, request, user_id):
+        me = request.user
+
+        if user_id is not None:
+            try:
+                user = Player.objects.get(id=user_id)
+                serializer = PlayerSerializer(user)
+            except Player.DoesNotExist:
+                return Response({'error': 'User does not exist'}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            return Response({'error': 'User ID is missing'}, status=status.HTTP_400_BAD_REQUEST)
+
+        # TODO 전적 추가할 때 내 프로필이랑 남의 프로필 나눠서 
+        if me == user: # 내 프로필 볼 때 
+            pass
+        else:       # 남의 프로필 볼 때
+            pass
+        
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+        
+
+        
+
+        
 


### PR DESCRIPTION
### 구현 사항
- 유저의 프로필 info 조회 api 구현

### 추가해야 할 사항
- 현재 게임 전적 정보가 미추가된 상태
- 추가 이후, 내 프로필과 타인 프로필을 조회할 때 전적 정보를 다르게 주어야 함
- 내 프로필: 내가 했던 대결들 / 타인 프로필: 해당 유저가 했던 대결들 + 나와 했던 대결들