### PR TITLE
feat: add chatroom user online status

### DIFF
--- a/pongWorld/chat/serializers/chat.py
+++ b/pongWorld/chat/serializers/chat.py
@@ -9,10 +9,13 @@ class ChatRoomSerializer(serializers.ModelSerializer):
     user2_nickname = serializers.CharField(source='user2.nickname', read_only=True)
     user1_profile_img = serializers.SerializerMethodField()
     user2_profile_img = serializers.SerializerMethodField()
+    user1_is_online = serializers.SerializerMethodField()
+    user2_is_online = serializers.SerializerMethodField()
+
 
     class Meta:
         model = ChatRoom
-        fields = ['id', 'user1', 'user1_nickname', 'user1_profile_img', 'user2', 'user2_nickname', 'user2_profile_img', 'unread_count']
+        fields = ['id', 'user1', 'user1_nickname', 'user1_profile_img', 'user1_is_online', 'user2', 'user2_nickname', 'user2_profile_img', 'user2_is_online', 'unread_count']
         read_only_fields = ['id', 'user1', 'user2', 'created_at', 'updated_at']
 
     def get_unread_count(self, obj) -> int:
@@ -39,6 +42,12 @@ class ChatRoomSerializer(serializers.ModelSerializer):
             return request.build_absolute_uri(obj.user2.profile_img.url)
         else:
             return None
+
+    def get_user1_is_online(self, obj) -> bool:
+        return obj.user1.online_count > 0
+
+    def get_user2_is_online(self, obj) -> bool:
+        return obj.user2.online_count > 0
 
 class MessageSerializer(serializers.ModelSerializer):
     nickname = serializers.SerializerMethodField()


### PR DESCRIPTION
### 구현사항
- 유저의 chatroom을 가져올 때(GET /chat/rooms/), 유저의 온라인 상태도 같이 보내줍니다
    - user1_is_online
    - user2_is_online  