### PR TITLE
feat: manage blocked user in chat

### DIFF
--- a/pongWorld/blocks/views/blocks.py
+++ b/pongWorld/blocks/views/blocks.py
@@ -3,6 +3,7 @@ from rest_framework import viewsets, status
 from rest_framework.response import Response
 from player.models import Player
 from friends.models import Friend
+from chat.models import ChatRoom
 from ..models import Block
 from ..serializers import BlockSerializer
 from django.db.models import Q
@@ -39,6 +40,17 @@ class BlocksView(viewsets.ModelViewSet):
         try:
             friend_instance = Friend.objects.get(friend_query)
             friend_instance.delete()
+        except ObjectDoesNotExist:
+            pass
+
+        chatroom_query = Q(user1_id=me.id) & Q(user2_id=to_block.id) | Q(user1_id=to_block.id) & Q(user2_id=me.id)
+        try:
+            chatroom_instance = ChatRoom.objects.get(chatroom_query)
+            if chatroom_instance.user1 == me:
+                chatroom_instance.is_user1_in = False
+            else:
+                chatroom_instance.is_user2_in = False
+            chatroom_instance.save()
         except ObjectDoesNotExist:
             pass
 

--- a/pongWorld/player/admin.py
+++ b/pongWorld/player/admin.py
@@ -3,5 +3,5 @@ from .models import Player
 
 @admin.register(Player)
 class PlayerAdmin(admin.ModelAdmin):
-    list_display = ("id", "nickname", "email", "profile_img", "intro", "matches", "wins", "total_score")
-    fields = ("nickname", "email", "profile_img", "intro", "matches", "wins", "total_score")
+    list_display = ("id", "nickname", "email", "profile_img", "intro", "matches", "wins", "total_score", "online_count")
+    fields = ("nickname", "email", "profile_img", "intro", "matches", "wins", "total_score", "online_count")


### PR DESCRIPTION
### 구현 내용 
- 블락 시 해당 유저와의 채팅방에서 나가도록 관리 (is_user_in = False)
- 블락한 유저의 메시지 전달하지 않음 (block한 유저의 메시지 send하지 않음)
- user_offline 보내주는 부분 에러 수정 (self.get_full_url(self.user.profile_img.url) -> CommonUtils.get_full_url(self.user.profile_img.url))