### PR TITLE
이중인및 계정삭제 기능 구현

### DIFF
--- a/pongWorld/player/models/player.py
+++ b/pongWorld/player/models/player.py
@@ -40,6 +40,8 @@ class Player(AbstractBaseUser, TimestampBaseModel, PermissionsMixin):
     total_score = models.PositiveIntegerField(default=1000)
     online_count = models.PositiveIntegerField(default=0)
     last_login_time = models.DateTimeField()
+    two_factor_auth_enabled = models.BooleanField(default=False)
+    auth_code = models.CharField(max_length=10, blank=True, null=True)
 
     objects = PlayerManager()
 

--- a/pongWorld/tcen_auth/urls.py
+++ b/pongWorld/tcen_auth/urls.py
@@ -9,7 +9,8 @@ urlpatterns = [
     path('42-login/', views.OAuthLoginURLView.as_view(), name='42_login'),
     path('pong-world-login/', views.OAuthCallbackView.as_view(), name='pong_world_login'),
     path('refresh-token/', TokenRefreshView.as_view(), name='token_refresh'),
-    # path('verify/', views.tcen_auth.verify_code_page, name='verify_code_page'),
+    path('verify/', views.VerifyCodePage.as_view(), name='verify_code_page'),
+    path('delete/', views.DeleteAccount.as_view(), name='delete_account'),
     # path('', views.home, name='home'),
 ]
 

--- a/pongWorld/tcen_auth/views/__init__.py
+++ b/pongWorld/tcen_auth/views/__init__.py
@@ -1,1 +1,1 @@
-from .tcen_auth import OAuthLoginURLView, OAuthCallbackView, CustomTokenRefreshView
+from .tcen_auth import OAuthLoginURLView, OAuthCallbackView, CustomTokenRefreshView, VerifyCodePage, DeleteAccount


### PR DESCRIPTION
사용자 인스턴스
   - 인증코드필드 추가
   - 이중인증여부 필드추가
    
이중인증
   - 이중인증 버튼 클릭시 → 인증페이지로 리다이렉션 → 이메일 발송버튼 클릭(get 요청) →  로그인 상태 확인 후 사용자의 메일로 인증코드 발송
   - 생성된 인증코드는 db에 저장
   - 확인버튼 클릭(post 요청) →   사용자의 입력코드와 db의 인증코드를 대조 후 일치하면  이중인증여부 True 설정
   
계정삭제
   - delete 버튼 클릭 →  delete요청 →  이중인증여부 True면 db에서 해당 유저 삭제 → 로그인 화면으로 리다이렉션(임시)
