### PR TITLE
chore: 분리된 회원 탈퇴 기능 하나로 통합

### DIFF
--- a/pongWorld/player/admin.py
+++ b/pongWorld/player/admin.py
@@ -3,5 +3,5 @@ from .models import Player
 
 @admin.register(Player)
 class PlayerAdmin(admin.ModelAdmin):
-    list_display = ("id", "nickname", "email", "profile_img", "intro", "matches", "wins", "total_score", "online_count")
-    fields = ("nickname", "email", "profile_img", "intro", "matches", "wins", "total_score", "online_count")
+    list_display = ("id", "nickname", "email", "profile_img", "intro", "matches", "wins", "total_score", "online_count", "two_factor_auth_enabled")
+    fields = ("nickname", "email", "profile_img", "intro", "matches", "wins", "total_score", "online_count", "two_factor_auth_enabled")

--- a/pongWorld/player/urls.py
+++ b/pongWorld/player/urls.py
@@ -8,7 +8,6 @@ urlpatterns = [
     path('online/<str:name>/', views.OnlinePlayerSearchView.as_view()),
     path('setting/', views.PlayerSettingView.as_view({'get': 'get_user_info'}), name="get_user_info"),
     path('setting/<int:pk>/', views.PlayerSettingView.as_view({'patch': 'partial_update'}), name="set_user_info"),
-    path('withdraw/', views.PlayerSettingView.as_view({'delete': 'withdraw'}), name="user_withdraw"),
     path('search/', views.SearchUserView.as_view({'get': 'get_all_users'}), name="get_all_users"),
     path('search/<str:name>/', views.SearchUserView.as_view({'get': 'get_users'}), name="get_users"),
     path('profile/', views.PlayerProfileView.as_view({'get': 'get_my_profile'}), name="my_profile"),

--- a/pongWorld/player/views/player.py
+++ b/pongWorld/player/views/player.py
@@ -44,23 +44,6 @@ class PlayerSettingView(viewsets.ModelViewSet):
         except Player.DoesNotExist:
             return Response({'error': 'User does not exist'}, status=status.HTTP_404_NOT_FOUND)
             
-    def withdraw(self, request):
-        try:
-            user_id = request.user.id
-            user = Player.objects.get(id=user_id)
-
-            # delete user profile image from media
-            profile_img_path = str(user.profile_img)
-            full_profile_img_path = os.path.join(settings.MEDIA_ROOT, profile_img_path)
-            if full_profile_img_path and default_storage.exists(full_profile_img_path):
-                default_storage.delete(full_profile_img_path)
-
-            user.delete()
-
-            return Response({'message': 'User successfully withdrawn'}, status=status.HTTP_204_NO_CONTENT)
-        except Player.DoesNotExist:
-            return Response({'error': 'User does not exist'}, status=status.HTTP_404_NOT_FOUND)
-        
 class CustomPlayerPagination(CursorPagination):
     page_size = 30
     ordering = '-last_login_time'

--- a/pongWorld/tcen_auth/views/tcen_auth.py
+++ b/pongWorld/tcen_auth/views/tcen_auth.py
@@ -20,6 +20,8 @@ from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from drf_spectacular.utils import extend_schema
 from django.http import JsonResponse
 import json
+import os
+from django.core.files.storage import default_storage
 
 from player.models import Player
 from ..serializers import (
@@ -272,14 +274,16 @@ class DeleteAccount(generics.GenericAPIView):
         user = request.user
 
         if user.two_factor_auth_enabled:
+            # delete user profile image from media
+            profile_img_path = str(user.profile_img)
+            full_profile_img_path = os.path.join(settings.MEDIA_ROOT, profile_img_path)
+            if full_profile_img_path and default_storage.exists(full_profile_img_path):
+                default_storage.delete(full_profile_img_path)
+
             user.delete()
             return Response({'message': 'Account successfully deleted'}, status=status.HTTP_200_OK)
         else:
             return Response({'error': 'Two-factor authentication is not enabled. Account deletion is not allowed.'}, status=status.HTTP_403_FORBIDDEN)
-
-
-
-
 
 
 # def oauth2callback(request):# 파라미터는 HttpRequest 객체 Django가 자동으로 뷰 함수에 전달됨


### PR DESCRIPTION
### 구현 사항
- 기존: 탈퇴 시 2FA 확인과 프로필 이미지 삭제가 분리 되어 있었음
- 하나로 통합하여 두 기능을 모두 수행하고 계정을 삭제하도록 함