### PR TITLE
fix: quick match에서 end game시 db 삭제 되는 오류 수정

### DIFF
--- a/pongWorld/game/socket/match_consumers.py
+++ b/pongWorld/game/socket/match_consumers.py
@@ -45,6 +45,7 @@ class RandomMatchConsumer(AsyncWebsocketConsumer): # Random PvP Game
             asyncio.create_task(RandomMatchConsumer.rooms[self.game.id].change_paddle_position(self.player.id, data['y_coordinate']))  # 백그라운드에서 실행
 
     async def end_game(self, data):
+        await self.channel_layer.group_discard(self.game_group_name, self.channel_name)
         if self.game.id in RandomMatchConsumer.rooms:
             del RandomMatchConsumer.rooms[self.game.id]
         await self.close()
@@ -127,6 +128,7 @@ class RandomMatchConsumer(AsyncWebsocketConsumer): # Random PvP Game
         ))
 
     async def disconnect(self, close_code):
+        await database_sync_to_async(self.game.refresh_from_db)()
         if self.player == self.game.player1 and self.game.status == 0:
             await database_sync_to_async(self.game.delete)()
 


### PR DESCRIPTION
### 수정 사항
- 문제: quick match game이 끝나고 end_game을 호출하면 해당 게임이 db에서 삭제 됨
- 원인: game의 status를 최신 상태로 업데이트 하지 않아서 조건문에 걸림
- 결과: rgame의 status를 최신 상태로 업데이트 후 end_game을 진행하니 게임이 삭제되지 않고 정상 종료 됨