### PR TITLE
fix: friend game 매칭/진행 중 퇴장할 때 db 지워지는 에러 수정

### DIFF
--- a/pongWorld/game/socket/match_consumers.py
+++ b/pongWorld/game/socket/match_consumers.py
@@ -429,6 +429,7 @@ class GameMixin:
 
     async def quit_competition(self, text_data_json):
         try:
+            await database_sync_to_async(self.game.refresh_from_db)()
             if self.player == self.game.player1 and self.game.status == 0:
                 await database_sync_to_async(self.game.delete)()
                 await self.channel_layer.group_discard(self.game_group_name, self.channel_name)


### PR DESCRIPTION
### 구현 사항
- 문제: friend game 매칭/진행 중 퇴장할 때 db가 계속 지워지는 에러가 발생
- 원인: game의 제대로 status가 업데이트 되지 않음
- 결과: refresh_from_db를 통해 game을 업데이트하고 퇴장하도록 수정